### PR TITLE
Restore messages on

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It shall NOT be edited by hand.
 
 SimpleX - the first messaging platform operating without user identifiers of any kind - 100% private by design! iOS and Android apps are released.
 
-**Shipped version:** 5.8.0~ynh1
+**Shipped version:** 5.8.0~ynh2
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -18,7 +18,7 @@ No se debe editar a mano.
 
 SimpleX - the first messaging platform operating without user identifiers of any kind - 100% private by design! iOS and Android apps are released.
 
-**Versión actual:** 5.8.0~ynh1
+**Versión actual:** 5.8.0~ynh2
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -18,7 +18,7 @@ EZ editatu eskuz.
 
 SimpleX - the first messaging platform operating without user identifiers of any kind - 100% private by design! iOS and Android apps are released.
 
-**Paketatutako bertsioa:** 5.8.0~ynh1
+**Paketatutako bertsioa:** 5.8.0~ynh2
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,7 +18,7 @@ Il NE doit PAS être modifié à la main.
 
 SimpleX - la première plate-forme de messagerie qui n'a aucun identifiant d'utilisateur d'aucune sorte - 100 % privée de par sa conception !
 
-**Version incluse :** 5.8.0~ynh1
+**Version incluse :** 5.8.0~ynh2
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -18,7 +18,7 @@ NON debe editarse manualmente.
 
 SimpleX - the first messaging platform operating without user identifiers of any kind - 100% private by design! iOS and Android apps are released.
 
-**Versión proporcionada:** 5.8.0~ynh1
+**Versión proporcionada:** 5.8.0~ynh2
 
 ## Capturas de pantalla
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -18,7 +18,7 @@
 
 SimpleX - the first messaging platform operating without user identifiers of any kind - 100% private by design! iOS and Android apps are released.
 
-**分发版本：** 5.8.0~ynh1
+**分发版本：** 5.8.0~ynh2
 
 ## 截图
 

--- a/conf/file-server.ini
+++ b/conf/file-server.ini
@@ -7,6 +7,12 @@
 # Log is compacted on start (deleted objects are removed).
 enable: on
 
+# Undelivered messages are optionally saved and restored when the server restarts,
+# they are preserved in the .bak file until the next restart.
+restore_messages: on
+#expire_messages_days: 21
+
+# Log daily server statistics to CSV file
 log_stats: off
 
 [AUTH]

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "SimpleX"
 description.en = "Messaging platform operating without user identifiers"
 description.fr = "Plate-forme de messagerie fonctionnant sans identifiants d'utilisateurs"
 
-version = "5.8.0~ynh1"
+version = "5.8.0~ynh2"
 
 maintainers = []
 


### PR DESCRIPTION
restore_messages: on

## Problem

- *After Simplex upgrade some people stopped receiving any messages from contacts and contacts’ statuses show network error: contact deleted*
https://forum.yunohost.org/t/simplex-upgrade-seems-to-have-wiped-some-server-data/29847

## Solution

- *Add restore messages on in file-server.ini*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
